### PR TITLE
additional microsoft linux mappings

### DIFF
--- a/unix/of.py
+++ b/unix/of.py
@@ -18,6 +18,8 @@ REPLACE_PATH = [
     ["/mnt/e/", "e:\\"], # microsoft linux
     ["/mnt/f/", "f:\\"], # microsoft linux
     ["/", "z:\\"],
+    # ["/root/", "%LOCALAPPDATA%\\lxss\\root\\"], # microsoft linux
+    # ["/", "%LOCALAPPDATA%\\lxss\\rootfs\\"], # microsoft linux
 ]
 
 


### PR DESCRIPTION
commented out by default because I've noticed sometimes editing lsxx files directly from windows causes them to "disappear" on the Linux side. A silly dance of renaming, recreating, pasting, and re-saving brings them back and then two-way editing works again.
